### PR TITLE
Feature/0 2/config/change domain and set https

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: "2"
 services:
-  reverse-proxy:
-    container_name: reverse-proxy-ai
-    build:
-      context: nginx/
-      dockerfile : Dockerfile
-    image: reverse-proxy-ai:latest
-    ports:
-      - 80:80
-    depends_on:
-      - ai-server
-
   ai-server:
     container_name: ai-server
     build:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,0 @@
-FROM nginx
-COPY ./conf.d /etc/nginx/conf.d
-EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -7,14 +7,14 @@ map $http_origin                    $cors_origin {
 
     default                         ""; #empty causes the Access-Control-Allow-Origin header to be empty
 
-    ~http://localhost:3000         "$http_origin";
-    ~http://testhelper.com         "$http_origin";
+    ~http://test-helper.com         "$http_origin";
+    ~http://api.test-helper.com         "$http_origin";
 
 }
 
 server { # ai server
     listen                      80;
-    server_name                 ai.testhelper.com;
+    server_name                 ai.test-helper.com;
 
     # cors
     add_header 'Access-Control-Allow-Origin' $cors_origin  always;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 upstream ai {
-    server                      ai-server:5000;
+    server                      localhost:5000;
     keepalive                   10;
 }
 
@@ -7,14 +7,21 @@ map $http_origin                    $cors_origin {
 
     default                         ""; #empty causes the Access-Control-Allow-Origin header to be empty
 
-    ~http://test-helper.com         "$http_origin";
-    ~http://api.test-helper.com         "$http_origin";
+    ~https://test-helper.com        "$http_origin";
+    ~https://api.test-helper.com    "$http_origin";
 
 }
 
 server { # ai server
-    listen                      80;
+    listen 443 ssl; # managed by Certbot
     server_name                 ai.test-helper.com;
+
+    #ssl
+    ssl_certificate /etc/letsencrypt/live/ai.test-helper.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/ai.test-helper.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
 
     # cors
     add_header 'Access-Control-Allow-Origin' $cors_origin  always;
@@ -30,7 +37,19 @@ server { # ai server
 
         proxy_set_header        HOST        $host;
         proxy_set_header        X-Real-IP   $remote_addr;
-        
+
         proxy_pass              http://ai;
     }
+}
+
+
+server {
+    if ($host = ai.test-helper.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    listen                      80;
+    server_name                 ai.test-helper.com;
+    return 404; # managed by Certbot
 }


### PR DESCRIPTION
기능 : 
- domain 변경 (ai.testhelper.com -> ai.test-helper.com)
- https 추가 완료

공지사항 : 
- EC2 AI 서버에 ai.test-helper.com을 통해 접속하면 https 가 적용되었습니다.
  - @WooNaYoung22 BE에서 AI 서버 접근 시 https://ai.test-helper.com을 활용하면 됩니다.
- 서버를 새로 띄우면 docker container를 새로 실행해야합니다. 해당 부분을 자동화하면 좋을 것 같습니다.
- 운영 서버일 때는 WSGI 서버를 사용하라는 경고가 뜨고 있어 추가 예정입니다.